### PR TITLE
Add new table settings popover

### DIFF
--- a/packages/client/src/components/table/Table.tsx
+++ b/packages/client/src/components/table/Table.tsx
@@ -27,6 +27,8 @@ import {
   useColumnVisibility,
   Sorting,
   ServerView,
+  useTableOverflow,
+  useTableDensity,
 } from "./utils";
 import { ColumnHeaderRow, FooterRow, ToolbarRow } from "./components";
 import { log } from "@compose/ts";
@@ -59,7 +61,7 @@ function Table({
   height,
   sortable = UI.Table.SORT_OPTION.MULTI,
   density = UI.Table.DENSITY.STANDARD,
-  overflow = "ellipsis",
+  overflow = UI.Table.OVERFLOW_BEHAVIOR.ELLIPSIS,
   filterable = true,
   primaryKey = undefined,
   views = [],
@@ -120,21 +122,15 @@ function Table({
     paginated,
   });
 
-  const tableOverflow = useMemo(() => {
-    if (viewsHook.applied.overflow) {
-      return viewsHook.applied.overflow;
-    }
+  const tableOverflowHook = useTableOverflow({
+    overflow,
+    appliedView: viewsHook.applied,
+  });
 
-    return overflow;
-  }, [viewsHook.applied, overflow]);
-
-  const tableDensity = useMemo(() => {
-    if (viewsHook.applied.density) {
-      return viewsHook.applied.density;
-    }
-
-    return density;
-  }, [viewsHook.applied, density]);
+  const tableDensityHook = useTableDensity({
+    density,
+    appliedView: viewsHook.applied,
+  });
 
   const sortingHook = Sorting.use({
     columns,
@@ -234,8 +230,8 @@ function Table({
     disableRowSelection,
     actions,
     onTableRowActionHook,
-    tableDensity,
-    tableOverflow,
+    tableDensityHook.applied,
+    tableOverflowHook.applied,
     toggleRowSelection
   );
 
@@ -431,6 +427,14 @@ function Table({
                 )
               );
 
+              if (viewsHook.appliedRef.current.density) {
+                tableDensityHook.set(viewsHook.appliedRef.current.density);
+              }
+
+              if (viewsHook.appliedRef.current.overflow) {
+                tableOverflowHook.set(viewsHook.appliedRef.current.overflow);
+              }
+
               // If paginated, request a new page of data from server
               if (paginated && handleRequestServerDataRef.current) {
                 handleRequestServerDataRef.current();
@@ -447,6 +451,14 @@ function Table({
               searchQueryHook.reset();
               advancedFilteringHook.reset();
 
+              if (viewsHook.appliedRef.current.density) {
+                tableDensityHook.set(viewsHook.appliedRef.current.density);
+              }
+
+              if (viewsHook.appliedRef.current.overflow) {
+                tableOverflowHook.set(viewsHook.appliedRef.current.overflow);
+              }
+
               // If paginated, request a new page of data from server
               if (paginated && handleRequestServerDataRef.current) {
                 handleRequestServerDataRef.current();
@@ -455,12 +467,14 @@ function Table({
               }
             }}
             isViewDirty={isViewDirty}
+            tableOverflowHook={tableOverflowHook}
+            tableDensityHook={tableDensityHook}
           />
           <TableBody
             table={table}
-            density={tableDensity}
+            density={tableDensityHook.applied}
             loading={loading}
-            overflow={tableOverflow}
+            overflow={tableOverflowHook.applied}
             setScrollToTopHandler={setScrollToTopHandler}
           />
           <FooterRow

--- a/packages/client/src/components/table/components/row/ToolbarRow.tsx
+++ b/packages/client/src/components/table/components/row/ToolbarRow.tsx
@@ -5,6 +5,8 @@ import {
   GlobalFiltering,
   Sorting,
   TanStackTable,
+  useTableDensity,
+  useTableOverflow,
   Views,
 } from "../../utils";
 import {
@@ -12,6 +14,7 @@ import {
   FilterColumnsPopover,
   PinAndHideColumnsPopover,
   SortColumnsPopover,
+  TableSettingsPopover,
   TableViewsPopover,
 } from "./toolbar-components";
 import { classNames } from "~/utils/classNames";
@@ -173,6 +176,8 @@ function ToolbarRow({
   setView,
   resetView,
   isViewDirty,
+  tableOverflowHook,
+  tableDensityHook,
 }: {
   searchQueryHook: ReturnType<typeof GlobalFiltering.useSearch>;
   advancedFilteringHook: ReturnType<
@@ -194,6 +199,8 @@ function ToolbarRow({
   setView: (view: Views.ViewDisplayFormat) => void;
   resetView: () => void;
   isViewDirty: boolean;
+  tableOverflowHook: ReturnType<typeof useTableOverflow>;
+  tableDensityHook: ReturnType<typeof useTableDensity>;
 }) {
   const offset =
     table.getState().pagination.pageIndex *
@@ -280,6 +287,14 @@ function ToolbarRow({
           table={table}
           paginated={paginated}
           defaultFileName={`${tableId}`}
+        />
+        <TableSettingsPopover
+          tableOverflow={tableOverflowHook.applied}
+          setTableOverflow={tableOverflowHook.set}
+          resetTableOverflow={tableOverflowHook.reset}
+          tableDensity={tableDensityHook.applied}
+          setTableDensity={tableDensityHook.set}
+          resetTableDensity={tableDensityHook.reset}
         />
         {views && views.length > 0 && (
           <>

--- a/packages/client/src/components/table/components/row/toolbar-components/TableSettings.tsx
+++ b/packages/client/src/components/table/components/row/toolbar-components/TableSettings.tsx
@@ -1,0 +1,160 @@
+import Button from "~/components/button";
+import Icon from "~/components/icon";
+import { classNames } from "~/utils/classNames";
+import { Popover } from "~/components/popover";
+import { UI } from "@composehq/ts-public";
+import RadioGroup from "~/components/radio-group";
+import { Divider } from "~/components/divider";
+
+function TableSettingsPanel({
+  className = "",
+  tableOverflow,
+  setTableOverflow,
+  resetTableOverflow,
+  tableDensity,
+  setTableDensity,
+  resetTableDensity,
+}: {
+  className?: string;
+  tableOverflow: UI.Table.OverflowBehavior;
+  setTableOverflow: (overflow: UI.Table.OverflowBehavior) => void;
+  resetTableOverflow: () => void;
+  tableDensity: UI.Table.Density;
+  setTableDensity: (density: UI.Table.Density) => void;
+  resetTableDensity: () => void;
+}) {
+  const resetAllSettings = () => {
+    resetTableOverflow();
+    resetTableDensity();
+  };
+
+  return (
+    <div
+      className={classNames("flex flex-col space-y-4 max-w-full", className)}
+    >
+      <div className="flex flex-row items-center justify-between">
+        <h5>Table settings</h5>
+        <Button
+          variant="ghost"
+          className="text-sm text-brand-neutral-2 hover:text-brand-neutral"
+          onClick={resetAllSettings}
+        >
+          Reset to default
+        </Button>
+      </div>
+
+      <div className="flex flex-col gap-4 pb-2">
+        <p className="text-sm text-brand-neutral-2 font-medium">
+          Cell overflow
+        </p>
+        <RadioGroup
+          options={[
+            {
+              label: "Ellipsis",
+              value: UI.Table.OVERFLOW_BEHAVIOR.ELLIPSIS,
+              description:
+                "Truncate text that overflows the cell with an ellipsis",
+            },
+            {
+              label: "Clip",
+              value: UI.Table.OVERFLOW_BEHAVIOR.CLIP,
+              description: "Clip any text that overflows the cell",
+            },
+            {
+              label: "Dynamic",
+              value: UI.Table.OVERFLOW_BEHAVIOR.DYNAMIC,
+              description: "Expand the cell height to fit the content",
+            },
+          ]}
+          value={tableOverflow}
+          setValue={(value) =>
+            setTableOverflow(value || UI.Table.OVERFLOW_BEHAVIOR.ELLIPSIS)
+          }
+          disabled={false}
+          label={null}
+        />
+      </div>
+
+      <Divider />
+
+      <div className="flex flex-col gap-4">
+        <p className="text-sm text-brand-neutral-2 font-medium">Density</p>
+        <RadioGroup
+          options={[
+            {
+              label: "Compact",
+              value: UI.Table.DENSITY.COMPACT,
+              description: "32px row height. Best for dense data.",
+            },
+            {
+              label: "Standard",
+              value: UI.Table.DENSITY.STANDARD,
+              description: "40px row height. Best for most data.",
+            },
+            {
+              label: "Comfortable",
+              value: UI.Table.DENSITY.COMFORTABLE,
+              description: "48px row height. Best for sparse data.",
+            },
+          ]}
+          value={tableDensity}
+          setValue={(value) =>
+            setTableDensity(value || UI.Table.DENSITY.STANDARD)
+          }
+          disabled={false}
+          label={null}
+        />
+      </div>
+    </div>
+  );
+}
+
+function TableSettingsPopover({
+  tableOverflow,
+  setTableOverflow,
+  resetTableOverflow,
+  tableDensity,
+  setTableDensity,
+  resetTableDensity,
+}: {
+  tableOverflow: UI.Table.OverflowBehavior;
+  setTableOverflow: (overflow: UI.Table.OverflowBehavior) => void;
+  resetTableOverflow: () => void;
+  tableDensity: UI.Table.Density;
+  setTableDensity: (density: UI.Table.Density) => void;
+  resetTableDensity: () => void;
+}) {
+  const hasActiveSettings =
+    tableOverflow !== UI.Table.OVERFLOW_BEHAVIOR.ELLIPSIS ||
+    tableDensity !== UI.Table.DENSITY.STANDARD;
+
+  return (
+    <Popover.Root>
+      <Popover.Trigger>
+        <div
+          data-tooltip-id="top-tooltip-offset4"
+          data-tooltip-content="Table settings"
+          data-tooltip-class-name="hidden sm:block"
+        >
+          <Icon
+            name="settings"
+            color={hasActiveSettings ? "brand-primary" : "brand-neutral-2"}
+          />
+        </div>
+      </Popover.Trigger>
+      <Popover.Panel>
+        <TableSettingsPanel
+          className="w-96"
+          tableOverflow={tableOverflow}
+          setTableOverflow={setTableOverflow}
+          resetTableOverflow={resetTableOverflow}
+          tableDensity={tableDensity}
+          setTableDensity={setTableDensity}
+          resetTableDensity={resetTableDensity}
+        />
+      </Popover.Panel>
+    </Popover.Root>
+  );
+}
+
+export { TableSettingsPopover };

--- a/packages/client/src/components/table/components/row/toolbar-components/index.ts
+++ b/packages/client/src/components/table/components/row/toolbar-components/index.ts
@@ -6,6 +6,7 @@ import {
 } from "./PinAndHideColumns";
 import { FilterColumnsPanel, FilterColumnsPopover } from "./FilterColumns";
 import { TableViewsPopover } from "./TableViews";
+import { TableSettingsPopover } from "./TableSettings";
 
 export {
   SortColumnsPanel,
@@ -17,4 +18,5 @@ export {
   FilterColumnsPanel,
   FilterColumnsPopover,
   TableViewsPopover,
+  TableSettingsPopover,
 };

--- a/packages/client/src/components/table/utils/index.ts
+++ b/packages/client/src/components/table/utils/index.ts
@@ -12,3 +12,5 @@ export * from "./rowSelections";
 export * as Views from "./views";
 export * from "./useColumnVisibility";
 export * from "./useDataControl";
+export * from "./useTableOverflow";
+export * from "./useTableDensity";

--- a/packages/client/src/components/table/utils/useTableDensity.ts
+++ b/packages/client/src/components/table/utils/useTableDensity.ts
@@ -1,0 +1,46 @@
+import { UI } from "@composehq/ts-public";
+import * as Views from "./views";
+import { useDataControl } from "./useDataControl";
+import { useCallback } from "react";
+
+function noop<T>(value: T) {
+  return value;
+}
+
+const isEqual = <T>(a: T, b: T) => a === b;
+
+function useTableDensity({
+  density,
+  appliedView,
+}: {
+  density: UI.Table.Density;
+  appliedView: Views.ViewValidatedFormat;
+}) {
+  const getCurrentServerValue = useCallback(() => {
+    if (appliedView.density) {
+      return appliedView.density;
+    }
+
+    return density;
+  }, [appliedView, density]);
+
+  const data = useDataControl<
+    UI.Table.Density,
+    UI.Table.Density,
+    UI.Table.Density
+  >({
+    isEnabled: true,
+    getCurrentServerValue,
+    getResetValue: getCurrentServerValue,
+    serverToDraft: noop,
+    draftToApplied: noop,
+    appliedToServer: noop,
+    serverValuesAreEqual: isEqual,
+    disabledValue: UI.Table.DENSITY.STANDARD,
+    paginated: false,
+  });
+
+  return data;
+}
+
+export { useTableDensity };

--- a/packages/client/src/components/table/utils/useTableOverflow.ts
+++ b/packages/client/src/components/table/utils/useTableOverflow.ts
@@ -1,0 +1,44 @@
+import { UI } from "@composehq/ts-public";
+import * as Views from "./views";
+import { useDataControl } from "./useDataControl";
+import { useCallback } from "react";
+
+function noop<T>(value: T) {
+  return value;
+}
+
+const isEqual = <T>(a: T, b: T) => a === b;
+
+function useTableOverflow({
+  overflow,
+  appliedView,
+}: {
+  overflow: UI.Table.OverflowBehavior;
+  appliedView: Views.ViewValidatedFormat;
+}) {
+  const getCurrentServerValue = useCallback(() => {
+    if (appliedView.overflow) {
+      return appliedView.overflow;
+    }
+
+    return overflow;
+  }, [appliedView, overflow]);
+
+  return useDataControl<
+    UI.Table.OverflowBehavior,
+    UI.Table.OverflowBehavior,
+    UI.Table.OverflowBehavior
+  >({
+    isEnabled: true,
+    getCurrentServerValue,
+    getResetValue: getCurrentServerValue,
+    serverToDraft: noop,
+    draftToApplied: noop,
+    appliedToServer: noop,
+    serverValuesAreEqual: isEqual,
+    disabledValue: UI.Table.OVERFLOW_BEHAVIOR.ELLIPSIS,
+    paginated: false,
+  });
+}
+
+export { useTableOverflow };


### PR DESCRIPTION
## Summary

Create a new table settings popover that allows users to directly toggle table density and overflow.

![CleanShot 2025-05-21 at 15 23 49](https://github.com/user-attachments/assets/ece894b9-39ed-4a36-b680-e9d5f80e6077)

Note: this PR exists, but may/may not be merged in.

## Discussion

### Pros

- Allows users access to more table features to toggle density/overflow directly.
- Fixes the cases where data is cut-off in a table cell. User can just toggle to the dynamic overflow mode.

### Cons

- Adds a 5th toolbar icon (too many...)
- A better solution to the data cut-off problem would be a hoverable overlay, not a settings menu!